### PR TITLE
ci: introduce C8S based GHA CI

### DIFF
--- a/.github/workflows/container.yml
+++ b/.github/workflows/container.yml
@@ -1,0 +1,52 @@
+name: Container
+on:
+    schedule:
+        -  cron: '30 11 * * *'
+    push:
+        branches: [ main ]
+        paths:
+            - 'test/container/**'
+            - '.github/workflows/container.yml'
+    pull_request:
+        branches: [ main ]
+        paths:
+            - 'test/container/**'
+            - '.github/workflows/container.yml'
+
+permissions:
+    packages: write
+    contents: read
+
+jobs:
+    push_to_registry:
+        name: Build and push containers image to GitHub Packages
+        runs-on: ubuntu-latest
+        concurrency:
+            group: ${{ github.workflow }}-${{ github.ref }}-${{ matrix.config.dockerfile }}
+            cancel-in-progress: true
+        strategy:
+            fail-fast: false
+            matrix:
+                config:
+                    # Use a prefixed image name to not conflict with the "centos"
+                    # image from redhat-plumbers/dracut-rhel9
+                    - { dockerfile: 'Dockerfile-CentOS-8-Stream',   tag: 'rhel8_centos:stream8' }
+        steps:
+            - name: Check out the repo
+              uses: actions/checkout@v2
+            - name: Set up Docker Buildx
+              uses: docker/setup-buildx-action@v1
+#              with:
+#                  buildkitd-flags: --debug
+            - name: Login to GitHub Container Registry
+              uses: docker/login-action@v1
+              with:
+                  registry: ghcr.io
+                  username: ${{ github.repository_owner }}
+                  password: ${{ secrets.GITHUB_TOKEN }}
+            - name: Build and Push Container
+              uses: docker/build-push-action@v2
+              with:
+                  file: test/container/${{ matrix.config.dockerfile }}
+                  tags: ghcr.io/${{ github.repository_owner }}/${{ matrix.config.tag }}
+                  push: ${{ github.event_name == 'push' ||  github.event_name == 'schedule' }}

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -29,9 +29,8 @@ jobs:
                         "13",
                         "17",
                         "20",
-                        #"21", needs backport (NFS + NM)
+                        "21",
                         "40",
-                        #"41", needws backport (NBD + NM)
                         "98",
                 ]
             fail-fast: false

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -1,0 +1,48 @@
+name: Integration Test
+
+on:
+    pull_request:
+        branches: [ main ]
+
+jobs:
+    centos-8-stream:
+        runs-on: ubuntu-latest
+        timeout-minutes: 45
+        concurrency:
+            group: ${{ github.workflow }}-${{ github.ref }}-${{ matrix.container }}-${{ matrix.test }}
+            cancel-in-progress: true
+        strategy:
+            matrix:
+                container: [
+                        "rhel8_centos:stream8",
+                ]
+                # Disabled tests (due to dropped packages in RHEL/CentOS):
+                # 03, 04, 15: requires btrfs
+                # 14: requires dmraid
+                # 30, 31, 35, 36: requires scsi-target-utils
+                test: [
+                        "01",
+                        "02",
+                        "10",
+                        "11",
+                        "12",
+                        "13",
+                        "17",
+                        "20",
+                        #"21", needs backport (NFS + NM)
+                        "40",
+                        #"41", needws backport (NBD + NM)
+                        "98",
+                ]
+            fail-fast: false
+        container:
+            image: ghcr.io/${{ github.repository_owner }}/${{ matrix.container }}
+            options: "--privileged -v /dev:/dev"
+        steps:
+            - name: "Checkout Repository"
+              uses: actions/checkout@v2
+              with:
+                  fetch-depth: 0
+
+            - name: "${{ matrix.container }} TEST-${{ matrix.test }}"
+              run: ./tools/test-github.sh "TEST-${{ matrix.test }}" ${{ matrix.test }}

--- a/test/TEST-20-NFS/test.sh
+++ b/test/TEST-20-NFS/test.sh
@@ -1,5 +1,13 @@
 #!/bin/bash
-TEST_DESCRIPTION="root filesystem on NFS"
+if [[ $NM ]]; then
+    USE_NETWORK="network-manager"
+    OMIT_NETWORK="network-legacy"
+else
+    USE_NETWORK="network-legacy"
+    OMIT_NETWORK="network-manager"
+fi
+
+TEST_DESCRIPTION="root filesystem on NFS with $USE_NETWORK"
 
 KVERSION=${KVERSION-$(uname -r)}
 
@@ -353,8 +361,8 @@ test_setup() {
 
     # Make client's dracut image
     $basedir/dracut.sh -l -i $TESTDIR/overlay / \
-        -o "plymouth dash" \
-        -a "debug watchdog" \
+        -o "plymouth dash ${OMIT_NETWORK}" \
+        -a "debug watchdog ${USE_NETWORK}" \
         -d "af_packet piix ide-gd_mod ata_piix sd_mod e1000 nfs sunrpc i6300esb" \
         --no-hostonly-cmdline -N \
         -f $TESTDIR/initramfs.testing $KVERSION || return 1

--- a/test/TEST-21-NFS-NM/Makefile
+++ b/test/TEST-21-NFS-NM/Makefile
@@ -1,0 +1,12 @@
+.PHONY: all setup clean run
+
+BASETEST=../TEST-20-NFS
+
+all:
+	@$(MAKE) NM=1 -s --no-print-directory -C $(BASETEST) all
+setup:
+	@$(MAKE) NM=1 -s --no-print-directory -C $(BASETEST) setup
+clean:
+	@$(MAKE) NM=1 -s --no-print-directory -C $(BASETEST) clean
+run:
+	@$(MAKE) NM=1 -s --no-print-directory -C $(BASETEST) run

--- a/test/container/Dockerfile-CentOS-8-Stream
+++ b/test/container/Dockerfile-CentOS-8-Stream
@@ -1,0 +1,54 @@
+FROM quay.io/centos/centos:stream8
+
+MAINTAINER https://github.com/dracutdevs/dracut
+
+ENV container docker
+LABEL RUN="docker run -it --name NAME --privileged --ipc=host --net=host --pid=host -e NAME=NAME -e IMAGE=IMAGE IMAGE"
+
+RUN echo 'export DRACUT_NO_XATTR=1 KVERSION=$(cd /lib/modules; ls -1 | tail -1)' > /etc/profile.d/dracut-test.sh
+
+# Install needed packages for the dracut CI container
+RUN dnf -y install epel-release && \
+    dnf -y install --enablerepo powertools --enablerepo epel --setopt=install_weak_deps=False \
+    qemu-kvm \
+    NetworkManager \
+    asciidoc \
+    bash-completion \
+    bzip2 \
+    cryptsetup \
+    dash \
+    dbus-daemon \
+    dhcp-client \
+    dhcp-server \
+    e2fsprogs \
+    gcc \
+    git \
+    iproute \
+    iputils \
+    iscsi-initiator-utils \
+    kbd \
+    kernel \
+    kmod-devel \
+    lvm2 \
+    make \
+    mdadm \
+    nfs-utils \
+    pigz \
+    python3-imgcreate \
+    rpm-build \
+    strace \
+    sudo \
+    tar \
+    tcpdump \
+    wget \
+    which \
+    xz \
+    && dnf -y update && dnf clean all
+
+# CentOS 8 ships only qemu-kvm, but it disables the KVM accel when it's not
+# available
+RUN ln -sv /usr/libexec/qemu-kvm /usr/bin/qemu-kvm && \
+    ln -sv /usr/libexec/qemu-kvm /usr/bin/qemu-system-$(uname -m)
+
+# Set default command
+CMD ["/usr/bin/bash"]

--- a/tools/test-github.sh
+++ b/tools/test-github.sh
@@ -1,0 +1,49 @@
+#!/bin/bash
+
+set -ex
+
+[[ -d ${0%/*} ]] && cd "${0%/*}"/../
+
+RUN_ID="$1"
+TESTS=$2
+
+./configure
+
+NCPU=$(getconf _NPROCESSORS_ONLN)
+
+if ! [[ $TESTS ]]; then
+    # GitHub workflows fetch a clone of the dracut repository which doesn't
+    # contain git tags, thus "breaking" the RPM build in certain situations
+    # i.e.:
+    # DRACUT_MAIN_VERSION in Makefile is defined as an output of `git describe`,
+    # which in full git clone returns a tag with a numeric version. However,
+    # without tags it returns SHA of the last commit, which later propagates into
+    # `Provides:` attribute of the built RPM and can break dependency tree when
+    # installed
+    [[ -d .git ]] && git fetch --tags && git describe --tags
+    make -j "$NCPU" all syncheck rpm logtee
+else
+    if [[ $TESTS == "99" ]]; then
+        [[ -d .git ]] && git fetch --tags && git describe --tags
+        make_docs=yes
+    else
+        make_docs=no
+    fi
+
+    make -j "$NCPU" enable_documentation=$make_docs all logtee
+
+    cd test
+
+    # shellcheck disable=SC2012
+    time LOGTEE_TIMEOUT_MS=590000 make \
+        enable_documentation=$make_docs \
+        KVERSION="$(
+            cd /lib/modules
+            ls -1 | tail -1
+        )" \
+        DRACUT_NO_XATTR=1 \
+        TEST_RUN_ID="$RUN_ID" \
+        ${TESTS:+TESTS="$TESTS"} \
+        -k V=1 \
+        check
+fi


### PR DESCRIPTION
I copied bits of upstream/RHEL9 dracut CI, so we have some coverage here as well. Also, to have some explicit network-scripts and NM coverage, I backported changes to TEST-21 which split it into two tests, each one testing one of the network modules.

@lnykryn PTAL

(Note: the test branch needs to be directly in the original repo, otherwise I wouldn't be able to test the privileged stuff)