### PR TITLE
(#1712424) fix(network): add errors and warnings when network interface does not exist

### DIFF
--- a/modules.d/35network-legacy/ifup.sh
+++ b/modules.d/35network-legacy/ifup.sh
@@ -413,7 +413,11 @@ for p in $(getargs ip=); do
 
     # If this option isn't directed at our interface, skip it
     if [ -n "$dev" ]; then
-        [ "$dev" != "$netif" ] && continue
+        if [ "$dev" != "$netif" ]; then
+            [ ! -e "/sys/class/net/$dev" ] \
+                && warn "Network interface '$dev' does not exist!"
+            continue
+        fi
     else
         iface_is_enslaved "$netif" && continue
     fi

--- a/modules.d/35network-legacy/parse-ip-opts.sh
+++ b/modules.d/35network-legacy/parse-ip-opts.sh
@@ -96,6 +96,11 @@ for p in $(getargs ip=); do
         fi
         # IFACES list for later use
         IFACES="$IFACES $dev"
+
+        # Interface should exist
+        if [ ! -e "/sys/class/net/$dev" ]; then
+            warn "Network interface '$dev' does not exist"
+        fi
     fi
 
     # Do we need to check for specific options?

--- a/modules.d/45ifcfg/write-ifcfg.sh
+++ b/modules.d/45ifcfg/write-ifcfg.sh
@@ -100,6 +100,11 @@ interface_bind() {
     local _netif="$1"
     local _macaddr="$2"
 
+    if [ ! -e "/sys/class/net/$_netif" ]; then
+        derror "Cannot find network interface '$_netif'!"
+        return 1
+    fi
+
     # see, if we can bind it to some hw parms
     if hw_bind "$_netif" "$_macaddr"; then
         # only print out DEVICE, if it's user assigned


### PR DESCRIPTION
End with error, or show a warning when nonexistent device is specified for network setup like
`ip=10.12.8.12::10.12.255.254:255.255.0.0:xk12:eth0:off`.

I've added the error only for `write-ifcfg.sh`, as I think no such setup should be written.

Resolves: #1712424

_ _ _ _

https://github.com/dracutdevs/dracut/pull/1652

Not tested.