### PR TITLE
(#2023665) fix(shutdown): be robust against forced shutdown

### DIFF
--- a/dracut-initramfs-restore.sh
+++ b/dracut-initramfs-restore.sh
@@ -6,6 +6,11 @@ set -e
 [ -e /run/initramfs/bin/sh ] && exit 0
 [ -e /run/initramfs/.need_shutdown ] || exit 0
 
+# SIGTERM signal is received upon forced shutdown: ignore the signal
+# We want to remain alive to be able to trap unpacking errors to avoid
+# switching root to an incompletely unpacked initramfs
+trap 'echo "Received SIGTERM signal, ignoring!" >&2' TERM
+
 KERNEL_VERSION="$(uname -r)"
 
 [[ $dracutbasedir ]] || dracutbasedir=/usr/lib/dracut


### PR DESCRIPTION
When a forced shutdown is issued through sending a burst of Ctrl-Alt-Del
keys, systemd sends SIGTERM to all processes. This ends up killing
dracut-initramfs-restore as well, preventing the script from detecting
that the unpack of the initramfs is incomplete, which later causes a
crash to happen when "shutdown" tries to execute from the unpacked
initramfs.

This fix makes sure dracut-initramfs-restore remains alive to detect
the unpack failed (because cpio was killed by systemd too).

Resolves: rhbz#2023665