### PR TITLE
(#1991449) fix(network-manager): write DHCP filename option to dhcpopts file

### DIFF
--- a/modules.d/35network-manager/nm-run.sh
+++ b/modules.d/35network-manager/nm-run.sh
@@ -22,7 +22,7 @@ do
     state=/run/NetworkManager/devices/$(cat $_i/ifindex)
     grep -q connection-uuid= $state 2>/dev/null || continue
     ifname=${_i##*/}
-    sed -n 's/root-path/new_root_path/p;s/next-server/new_next_server/p' <$state >/tmp/dhclient.$ifname.dhcpopts
+    sed -n 's/root-path/new_root_path/p;s/next-server/new_next_server/p;s/dhcp-bootfile/filename/p' <$state >/tmp/dhclient.$ifname.dhcpopts
     source_hook initqueue/online $ifname
     /sbin/netroot $ifname
 done


### PR DESCRIPTION
Anaconda parses the 'filename' variable [1] set in /tmp/net.$netif.dhcpopts to determine the name of the kickstart file to use.

[1] https://github.com/rhinstaller/anaconda/blob/anaconda-35.21-1/dracut/fetch-kickstart-net.sh#L31-L34

(Cherry-picked from commit 1513505db452f9425ae1d25b9bb28c176d9c7ed9)

Resolves: rhbz#1991449