### PR TITLE
#(2141480) fix(80lvmthinpool-monitor): use systemsctl instead of $SYSTEMCTL

### DIFF
--- a/modules.d/80lvmthinpool-monitor/module-setup.sh
+++ b/modules.d/80lvmthinpool-monitor/module-setup.sh
@@ -20,5 +20,5 @@ install() {
     inst_script "$moddir/start-thinpool-monitor.sh" "/bin/start-thinpool-monitor"
 
     inst "$moddir/start-thinpool-monitor.service" "$systemdsystemunitdir/start-thinpool-monitor.service"
-    $SYSTEMCTL -q --root "$initdir" add-wants initrd.target start-thinpool-monitor.service
+    systemctl -q --root "$initdir" add-wants initrd.target start-thinpool-monitor.service
 }


### PR DESCRIPTION
as the change is not backported to RHEL-8.

rhel-only

Resolves: #2141480