### PR TITLE
fix(dracut-init): use ldconfig directly instead of DRACUT_LDCONFIG

### DIFF
--- a/dracut-init.sh
+++ b/dracut-init.sh
@@ -448,7 +448,7 @@ build_ld_cache() {
     for f in "$dracutsysrootdir"/etc/ld.so.conf "$dracutsysrootdir"/etc/ld.so.conf.d/*; do
         [[ -f $f ]] && inst_simple "${f#$dracutsysrootdir}"
     done
-    if ! $DRACUT_LDCONFIG -r "$initdir" -f /etc/ld.so.conf; then
+    if ! ldconfig -r "$initdir" -f /etc/ld.so.conf; then
         if [[ $EUID == 0 ]]; then
             derror "ldconfig exited ungracefully"
         else


### PR DESCRIPTION
RHEL-only
Resolves: #2141480