### PR TITLE
fix(dracut-init.sh): backport DRACUT_* paths

### DIFF
--- a/dracut-init.sh
+++ b/dracut-init.sh
@@ -79,6 +79,10 @@ export srcmods
     export hookdirs
 }
 
+DRACUT_LDD=${DRACUT_LDD:-ldd}
+DRACUT_TESTBIN=${DRACUT_TESTBIN:-/bin/sh}
+DRACUT_LDCONFIG=${DRACUT_LDCONFIG:-ldconfig}
+
 . $dracutbasedir/dracut-functions.sh
 
 # Detect lib paths

--- a/dracut.sh
+++ b/dracut.sh
@@ -730,6 +730,8 @@ done
 export PATH="${NPATH#:}"
 unset NPATH
 
+export SYSTEMCTL=${SYSTEMCTL:-systemctl}
+
 # these options add to the stuff in the config file
 (( ${#add_dracutmodules_l[@]} )) && add_dracutmodules+=" ${add_dracutmodules_l[@]} "
 (( ${#force_add_dracutmodules_l[@]} )) && force_add_dracutmodules+=" ${force_add_dracutmodules_l[@]} "


### PR DESCRIPTION
while backporting, some paths might be expected to be defined. Backporting these paths as a preemptive measure (there's no test / check) to avoid possible regressions.

(Cherry-picked from a01204202b3014c0c761c93bc7de8bf35e6dc5ef)

RHEL-only
Resolves: #2141480