### PR TITLE
feat(hwdb): install hwdb on demand when module is needed

### DIFF
--- a/dracut.sh
+++ b/dracut.sh
@@ -1302,6 +1302,12 @@ if ! [[ -d "$udevdir" ]]; then
     [[ -e /usr/lib/udev/collect ]] && udevdir=/usr/lib/udev
 fi
 
+[[ -d $udevconfdir ]] \
+    || udevconfdir="$(pkg-config udev --variable=udevconfdir 2>/dev/null)"
+if ! [[ -d "$udevconfdir" ]]; then
+    [[ -d /etc/udev ]] && udevconfdir=/etc/udev
+fi
+
 [[ -d $systemdutildir ]] \
     || systemdutildir=$(pkg-config systemd --variable=systemdutildir 2>/dev/null)
 

--- a/dracut.spec
+++ b/dracut.spec
@@ -365,6 +365,7 @@ echo 'dracut_rescue_image="yes"' > $RPM_BUILD_ROOT%{dracutlibdir}/dracut.conf.d/
 %{dracutlibdir}/modules.d/91crypt-loop
 %{dracutlibdir}/modules.d/95debug
 %{dracutlibdir}/modules.d/95fstab-sys
+%{dracutlibdir}/modules.d/95hwdb
 %{dracutlibdir}/modules.d/95lunmask
 %{dracutlibdir}/modules.d/95nvmf
 %{dracutlibdir}/modules.d/95resume

--- a/modules.d/95hwdb/module-setup.sh
+++ b/modules.d/95hwdb/module-setup.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+# This file is part of dracut.
+# SPDX-License-Identifier: GPL-2.0-or-later
+
+check() {
+    return 255
+}
+
+# called by dracut
+install() {
+    local hwdb_bin
+
+    # systemd-hwdb ships the file in /etc, with /usr/lib as an alternative.
+    # Therefore consider this location as preferred for configuration.
+    hwdb_bin="${udevdir}"/hwdb.bin
+
+    if [[ ! -r "${hwdb_bin}" ]]; then
+      hwdb_bin="${udevconfdir}"/hwdb.bin
+    fi
+
+    if [[ $hostonly ]]; then
+        inst_multiple -H "${hwdb_bin}"
+    else
+        inst_multiple "${hwdb_bin}"
+    fi
+}


### PR DESCRIPTION
Adding a module to install hwdb. Further extensions might make only selected part of hwdb installable, to save space. The module is not included by default.

Including the module adds 2MB of compressed data (on Fedora, the file has 12MB).

hwdb is needed in case of custom HW, like a keyboard/mouse or various interfaces.

Original PR: https://github.com/dracutdevs/dracut/pull/1681

(Cherry-picked commit: ae2ab8c8a65c4ea4f4ad4e8c8f99d493a8f686eb)

Resolves: #1968118