### PR TITLE
feat(systemd): install systemd-sysroot-fstab-check

### DIFF
--- a/modules.d/00systemd/module-setup.sh
+++ b/modules.d/00systemd/module-setup.sh
@@ -47,6 +47,7 @@ install() {
         $systemdutildir/systemd-sysctl \
         $systemdutildir/systemd-modules-load \
         $systemdutildir/systemd-vconsole-setup \
+        $systemdutildir/systemd-sysroot-fstab-check \
         $systemdutildir/system-generators/systemd-fstab-generator \
         $systemdutildir/system-generators/systemd-gpt-auto-generator \
         \


### PR DESCRIPTION
systemd-sysroot-fstab-check is a symlink to systemd-fstab-generator added in systemd commit https://github.com/systemd/systemd/commit/cd7ad0cb

(cherry picked from commit 23684e4a2bb024595ad63d9f49d83b4693537110)

Resolves: RHEL-12408