### PR TITLE
fix(udev-rules): keep network device naming scheme on upgrade

### DIFF
--- a/modules.d/95udev-rules/module-setup.sh
+++ b/modules.d/95udev-rules/module-setup.sh
@@ -55,6 +55,8 @@ install() {
     inst_rules 91-permissions.rules
     # eudev rules
     inst_rules 80-drivers-modprobe.rules
+    # legacy persistent network device name rules
+    [[ $hostonly ]] && inst_rules 70-persistent-net.rules
 
     if dracut_module_included "systemd"; then
         inst_multiple -o ${systemdutildir}/network/*.link


### PR DESCRIPTION
(Cherry-picked commit: 2fc6cd37e61e53333d57164eee79e90c6adcade6)

Resolves: RHEL-9480