### PR TITLE
fix(iscsi): do not exit in handle_netroot() if discovery failed

### DIFF
--- a/modules.d/95iscsi/iscsiroot.sh
+++ b/modules.d/95iscsi/iscsiroot.sh
@@ -211,7 +211,7 @@ handle_netroot()
     fi
 
     targets=$(iscsiadm -m discovery -t st -p $iscsi_target_ip:${iscsi_target_port:+$iscsi_target_port} | sed 's/^.*iqn/iqn/')
-    [ -z "$targets" ] && echo "Target discovery to $iscsi_target_ip:${iscsi_target_port:+$iscsi_target_port} failed with status $?" && exit 1
+    [ -z "$targets" ] && echo "Target discovery to $iscsi_target_ip:${iscsi_target_port:+$iscsi_target_port} failed with status $?" && return 1
 
     found=
     for target in $targets; do


### PR DESCRIPTION
User may specify multiple netroot in cmdline, failed to connect one netroot do not mean all netroot are not accessible. So if one netroot failed, do not exit the discovery and login flow.

Signed-off-by: Wenchao Hao <haowenchao@huawei.com>

(Cherry-picked commit: 319dc7fe10585a19d1a051f8ad1ba0190f86ff1f)

Resolves: RHEL-11779