### PR TITLE
fix(multipath): disable user_friendly_names with mpathconf

### DIFF
--- a/modules.d/90multipath/multipathd-configure.service
+++ b/modules.d/90multipath/multipathd-configure.service
@@ -13,7 +13,7 @@ ConditionPathExists=!/etc/multipath.conf
 [Service]
 Type=oneshot
 ExecStartPre=-/usr/bin/mkdir -p /etc/multipath/multipath.conf.d
-ExecStart=/usr/sbin/mpathconf --enable
+ExecStart=/usr/sbin/mpathconf --enable --user_friendly_names n
 
 [Install]
 WantedBy=sysinit.target

--- a/modules.d/90multipath/multipathd.sh
+++ b/modules.d/90multipath/multipathd.sh
@@ -2,7 +2,7 @@
 
 if [ "$(getarg rd.multipath)" = "default" ] && [ ! -e /etc/multipath.conf ]; then
     mkdir -p /etc/multipath/multipath.conf.d
-    mpathconf --enable
+    mpathconf --enable --user_friendly_names n
 fi
 
 if getargbool 1 rd.multipath -d -n rd_NO_MULTIPATH && [ -e /etc/multipath.conf ]; then


### PR DESCRIPTION
If dracut is creating /etc/multipath.conf by calling mpathconf in either multipathd-configure.service or multipathd.sh, there is a chance that the multipath config in the real root differs. Specifically, it might have chosen different user_friendly_names for the devices. When the systems switches to the real root, multipath may not be able to switch the devices to their configured names because those might already be in use. To avoid this, call mpathconf with "--user_friendly_names n" to create a multipath.conf with user_friendly_names disabled. If all devices use WWID names, it is always possible for multipath to rename them later.

Fixes b8a92b715 ("multipath: add automatic configuration for multipath")

(cherry picked from commit f36f2869859eb5f9613a94a28dfaf31505e645cc)

Resolves: RHEL-91319